### PR TITLE
[shared_preferences] Use path_provider directly in windows/linux

### DIFF
--- a/packages/shared_preferences/shared_preferences/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.16
+
+* Use path_provider directly in windows/linux
+
 ## 2.0.15
 
 * Minor fixes for new analysis options.

--- a/packages/shared_preferences/shared_preferences/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for reading and writing simple key-value pairs.
   Wraps NSUserDefaults on iOS and SharedPreferences on Android.
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.0.15
+version: 2.0.16
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
@@ -30,11 +30,11 @@ dependencies:
     sdk: flutter
   shared_preferences_android: ^2.0.8
   shared_preferences_ios: ^2.0.8
-  shared_preferences_linux: ^2.0.1
+  shared_preferences_linux: ^2.0.2
   shared_preferences_macos: ^2.0.0
   shared_preferences_platform_interface: ^2.0.0
   shared_preferences_web: ^2.0.0
-  shared_preferences_windows: ^2.0.1
+  shared_preferences_windows: ^2.0.2
 
 dev_dependencies:
   flutter_driver:

--- a/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.2
+
+* Use path_provider directly in windows/linux
+
 ## 2.1.1
 
 * Removes unnecessary imports.

--- a/packages/shared_preferences/shared_preferences_linux/lib/shared_preferences_linux.dart
+++ b/packages/shared_preferences/shared_preferences_linux/lib/shared_preferences_linux.dart
@@ -9,7 +9,7 @@ import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:path/path.dart' as path;
-import 'package:path_provider_linux/path_provider_linux.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 
 /// The Linux implementation of [SharedPreferencesStorePlatform].
@@ -33,14 +33,10 @@ class SharedPreferencesLinux extends SharedPreferencesStorePlatform {
   @visibleForTesting
   FileSystem fs = const LocalFileSystem();
 
-  /// The path_provider_linux instance used to find the support directory.
-  @visibleForTesting
-  PathProviderLinux pathProvider = PathProviderLinux();
-
   /// Gets the file where the preferences are stored.
   Future<File?> _getLocalDataFile() async {
-    final String? directory = await pathProvider.getApplicationSupportPath();
-    if (directory == null) {
+    final String directory = (await getApplicationSupportDirectory()).path;
+    if (directory.isEmpty) {
       return null;
     }
     return fs.file(path.join(directory, 'shared_preferences.json'));

--- a/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_linux
 description: Linux implementation of the shared_preferences plugin
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_linux
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.1.1
+version: 2.1.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_linux/pubspec.yaml
@@ -20,8 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   path: ^1.8.0
-  path_provider_linux: ^2.0.0
-  path_provider_platform_interface: ^2.0.0
+  path_provider: ^2.0.0
   shared_preferences_platform_interface: ^2.0.0
 
 dev_dependencies:

--- a/packages/shared_preferences/shared_preferences_linux/test/shared_preferences_linux_test.dart
+++ b/packages/shared_preferences/shared_preferences_linux/test/shared_preferences_linux_test.dart
@@ -4,25 +4,24 @@
 import 'package:file/memory.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as path;
-import 'package:path_provider_linux/path_provider_linux.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:shared_preferences_linux/shared_preferences_linux.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 
 void main() {
   late MemoryFileSystem fs;
-  late PathProviderLinux pathProvider;
 
   SharedPreferencesLinux.registerWith();
 
   setUp(() {
     fs = MemoryFileSystem.test();
-    pathProvider = FakePathProviderLinux();
+    PathProviderPlatform.instance = FakePathProviderLinux();
   });
 
   Future<String> _getFilePath() async {
-    final String? directory = await pathProvider.getApplicationSupportPath();
-    return path.join(directory!, 'shared_preferences.json');
+    final String directory = (await getApplicationSupportDirectory()).path;
+    return path.join(directory, 'shared_preferences.json');
   }
 
   Future<void> _writeTestFile(String value) async {
@@ -38,7 +37,6 @@ void main() {
   SharedPreferencesLinux _getPreferences() {
     final SharedPreferencesLinux prefs = SharedPreferencesLinux();
     prefs.fs = fs;
-    prefs.pathProvider = pathProvider;
     return prefs;
   }
 
@@ -91,8 +89,7 @@ void main() {
 ///
 /// Note that this should only be used with an in-memory filesystem, as the
 /// path it returns is a root path that does not actually exist on Linux.
-class FakePathProviderLinux extends PathProviderPlatform
-    implements PathProviderLinux {
+class FakePathProviderLinux extends PathProviderPlatform {
   @override
   Future<String?> getApplicationSupportPath() async => r'/appsupport';
 

--- a/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
+++ b/packages/shared_preferences/shared_preferences_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.2
+
+* Use path_provider directly in windows/linux
+
 ## 2.1.1
 
 * Fixes library_private_types_in_public_api, sort_child_properties_last and use_key_in_widget_constructors

--- a/packages/shared_preferences/shared_preferences_windows/lib/shared_preferences_windows.dart
+++ b/packages/shared_preferences/shared_preferences_windows/lib/shared_preferences_windows.dart
@@ -9,7 +9,7 @@ import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:path/path.dart' as path;
-import 'package:path_provider_windows/path_provider_windows.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 
 /// The Windows implementation of [SharedPreferencesStorePlatform].
@@ -30,10 +30,6 @@ class SharedPreferencesWindows extends SharedPreferencesStorePlatform {
   @visibleForTesting
   FileSystem fs = const LocalFileSystem();
 
-  /// The path_provider_windows instance used to find the support directory.
-  @visibleForTesting
-  PathProviderWindows pathProvider = PathProviderWindows();
-
   /// Local copy of preferences
   Map<String, Object>? _cachedPreferences;
 
@@ -45,8 +41,8 @@ class SharedPreferencesWindows extends SharedPreferencesStorePlatform {
     if (_localDataFilePath != null) {
       return _localDataFilePath!;
     }
-    final String? directory = await pathProvider.getApplicationSupportPath();
-    if (directory == null) {
+    final String directory = (await getApplicationSupportDirectory()).path;
+    if (directory.isEmpty) {
       return null;
     }
     return _localDataFilePath =

--- a/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: shared_preferences_windows
 description: Windows implementation of shared_preferences
 repository: https://github.com/flutter/plugins/tree/main/packages/shared_preferences/shared_preferences_windows
 issue_tracker: https://github.com/flutter/flutter/issues?q=is%3Aissue+is%3Aopen+label%3A%22p%3A+shared_preferences%22
-version: 2.1.1
+version: 2.1.2
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
@@ -21,7 +21,6 @@ dependencies:
     sdk: flutter
   path: ^1.8.0
   path_provider: ^2.0.0
-  path_provider_windows: ^2.0.0
   shared_preferences_platform_interface: ^2.0.0
 
 dev_dependencies:

--- a/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
+++ b/packages/shared_preferences/shared_preferences_windows/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   path: ^1.8.0
-  path_provider_platform_interface: ^2.0.0
+  path_provider: ^2.0.0
   path_provider_windows: ^2.0.0
   shared_preferences_platform_interface: ^2.0.0
 

--- a/packages/shared_preferences/shared_preferences_windows/test/shared_preferences_windows_test.dart
+++ b/packages/shared_preferences/shared_preferences_windows/test/shared_preferences_windows_test.dart
@@ -5,23 +5,22 @@
 import 'package:file/memory.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
-import 'package:path_provider_windows/path_provider_windows.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
 import 'package:shared_preferences_windows/shared_preferences_windows.dart';
 
 void main() {
   late MemoryFileSystem fileSystem;
-  late PathProviderWindows pathProvider;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
-    pathProvider = FakePathProviderWindows();
+    PathProviderPlatform.instance = FakePathProviderWindows();
   });
 
   Future<String> _getFilePath() async {
-    final String? directory = await pathProvider.getApplicationSupportPath();
-    return path.join(directory!, 'shared_preferences.json');
+    final String directory = (await getApplicationSupportDirectory()).path;
+    return path.join(directory, 'shared_preferences.json');
   }
 
   Future<void> _writeTestFile(String value) async {
@@ -37,7 +36,6 @@ void main() {
   SharedPreferencesWindows _getPreferences() {
     final SharedPreferencesWindows prefs = SharedPreferencesWindows();
     prefs.fs = fileSystem;
-    prefs.pathProvider = pathProvider;
     return prefs;
   }
 
@@ -90,10 +88,7 @@ void main() {
 ///
 /// Note that this should only be used with an in-memory filesystem, as the
 /// path it returns is a root path that does not actually exist on Windows.
-class FakePathProviderWindows extends PathProviderPlatform
-    implements PathProviderWindows {
-  @override
-  late VersionInfoQuerier versionInfoQuerier;
+class FakePathProviderWindows extends PathProviderPlatform {
 
   @override
   Future<String?> getApplicationSupportPath() async => r'C:\appsupport';
@@ -110,6 +105,4 @@ class FakePathProviderWindows extends PathProviderPlatform
   @override
   Future<String?> getDownloadsPath() async => null;
 
-  @override
-  Future<String> getPath(String folderID) async => '';
 }


### PR DESCRIPTION
In some cases, the path_provider needs to be customized by the upper layer, and the direct use of path_provider_windows/path_provider_linux limits this situation.

link: https://github.com/flutter/flutter/issues/106194
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [relevant style guides] and ran [the auto-formatter]. (Unlike the flutter/flutter repo, the flutter/plugins repo does use `dart format`.)
- [x] I signed the [CLA].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. `[shared_preferences]`
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is [exempt from version changes].
- [x] I updated `CHANGELOG.md` to add a description of the change, [following repository CHANGELOG style].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[relevant style guides]: https://github.com/flutter/plugins/blob/main/CONTRIBUTING.md#style
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[exempt from version changes]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#version-and-changelog-updates
[following repository CHANGELOG style]: https://github.com/flutter/flutter/wiki/Contributing-to-Plugins-and-Packages#changelog-style
[the auto-formatter]: https://github.com/flutter/plugins/blob/main/script/tool/README.md#format-code
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
